### PR TITLE
Remove symlinks

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -1,1 +1,0 @@
-amp-wp/amp.php

--- a/jetpack.php
+++ b/jetpack.php
@@ -1,1 +1,0 @@
-jetpack/jetpack.php

--- a/media-explorer.php
+++ b/media-explorer.php
@@ -1,1 +1,0 @@
-media-explorer/media-explorer.php

--- a/rewrite-rules-inspector.php
+++ b/rewrite-rules-inspector.php
@@ -1,1 +1,0 @@
-Rewrite-Rules-Inspector/rewrite-rules-inspector.php

--- a/vip-plugins.php
+++ b/vip-plugins.php
@@ -1,0 +1,7 @@
+<?php
+
+require __DIR__ . '/amp-wp/amp.php';
+require __DIR__ . '/jetpack/jetpack.php';
+require __DIR__ . '/media-explorer/media-explorer.php';
+require __DIR__ . '/Rewrite-Rules-Inspector/rewrite-rules-inspector.php';
+require __DIR__ . '/writing-helper/writing-helper.php';

--- a/writing-helper.php
+++ b/writing-helper.php
@@ -1,1 +1,0 @@
-writing-helper/writing-helper.php


### PR DESCRIPTION
Windows doesn't support symlinks, so let's require the files in PHP
instead.

Fixes #8